### PR TITLE
Add client shared pref

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/di/DataModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/di/DataModule.kt
@@ -1,9 +1,13 @@
 package ru.practicum.android.diploma.di
 
+import android.content.Context
+import android.content.SharedPreferences
 import androidx.room.Room
+import com.google.gson.Gson
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 import ru.practicum.android.diploma.db.AppDatabase
+import ru.practicum.android.diploma.sharedPref.impl.FiltersStorageImpl
 
 const val DATABASE_NAME = "favorite_vacancy"
 
@@ -21,6 +25,13 @@ class DataModule {
         }
 
         single { get<AppDatabase>().favoriteVacancyDao() }
+
+        single<SharedPreferences>{
+            androidContext().getSharedPreferences(FiltersStorageImpl.KEY_SAVED_PARAMS_FILTER,Context.MODE_PRIVATE)
+        }
+
+        single { Gson() }
+
 
     }
 

--- a/app/src/main/java/ru/practicum/android/diploma/filter/data/impl/dto/ParamsFilterModelDto.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/data/impl/dto/ParamsFilterModelDto.kt
@@ -1,0 +1,13 @@
+package ru.practicum.android.diploma.filter.data.impl.dto
+
+data class ParamsFilterModelDto(
+    val idCountry: String?,
+    val idArea: String?,
+    val idIndustry: String?,
+    val nameCountry: String?,
+    val nameArea: String?,
+    val nameIndustry: String?,
+    val currency: String?,
+    val salary: Int?,
+    val onlyWithSalary: Boolean,
+)

--- a/app/src/main/java/ru/practicum/android/diploma/filter/data/impl/dto/ParamsMapper.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/data/impl/dto/ParamsMapper.kt
@@ -1,0 +1,5 @@
+package ru.practicum.android.diploma.filter.data.impl.dto
+
+object ParamsMapper {
+
+}

--- a/app/src/main/java/ru/practicum/android/diploma/filter/data/impl/dto/ParamsMapper.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/data/impl/dto/ParamsMapper.kt
@@ -1,5 +1,36 @@
 package ru.practicum.android.diploma.filter.data.impl.dto
 
+import ru.practicum.android.diploma.filter.domain.models.ParamsFilterModel
+
 object ParamsMapper {
 
+    fun paramsModelInParamsModelDto(model:ParamsFilterModel): ParamsFilterModelDto {
+        return ParamsFilterModelDto(
+            idCountry = model.idCountry,
+            idArea =  model.idArea,
+            idIndustry = model.idIndustry,
+            nameCountry = model.nameCountry,
+            nameArea = model.nameArea,
+            nameIndustry = model.nameIndustry,
+            currency = model.currency,
+            salary = model.salary,
+            onlyWithSalary = model.onlyWithSalary
+
+        )
+    }
+
+    fun paramsModelDtoInParamsModel(model:ParamsFilterModelDto):ParamsFilterModel{
+        return ParamsFilterModel(
+            idCountry = model.idCountry,
+            idArea =  model.idArea,
+            idIndustry = model.idIndustry,
+            nameCountry = model.nameCountry,
+            nameArea = model.nameArea,
+            nameIndustry = model.nameIndustry,
+            currency = model.currency,
+            salary = model.salary,
+            onlyWithSalary = model.onlyWithSalary
+
+        )
+    }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/filter/domain/models/ParamsFilterModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/domain/models/ParamsFilterModel.kt
@@ -1,0 +1,14 @@
+package ru.practicum.android.diploma.filter.domain.models
+
+data class ParamsFilterModel(
+    val idCountry: String?,
+    val idArea:String?,
+    val idIndustry:String?,
+    val nameCountry:String?,
+    val nameArea: String?,
+    val nameIndustry:String?,
+    val currency:String?,
+    val salary:Int?,
+    val onlyWithSalary:Boolean,
+)
+

--- a/app/src/main/java/ru/practicum/android/diploma/sharedPref/FiltersStorage.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/sharedPref/FiltersStorage.kt
@@ -4,5 +4,7 @@ import ru.practicum.android.diploma.filter.data.impl.dto.ParamsFilterModelDto
 
 interface FiltersStorage {
 
-    fun getParamsFiltres():ParamsFilterModelDto?
+    fun getParamsFilters():ParamsFilterModelDto?
+
+    fun addParamsFilters(params:ParamsFilterModelDto)
 }

--- a/app/src/main/java/ru/practicum/android/diploma/sharedPref/FiltersStorage.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/sharedPref/FiltersStorage.kt
@@ -1,4 +1,4 @@
-package ru.practicum.android.diploma.sharedPref.impl
+package ru.practicum.android.diploma.sharedPref
 
 import ru.practicum.android.diploma.filter.data.impl.dto.ParamsFilterModelDto
 

--- a/app/src/main/java/ru/practicum/android/diploma/sharedPref/FiltersStorage.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/sharedPref/FiltersStorage.kt
@@ -4,7 +4,5 @@ import ru.practicum.android.diploma.filter.data.impl.dto.ParamsFilterModelDto
 
 interface FiltersStorage {
 
-    fun getStateSavedFilters():Boolean
-
-    fun getParamsFiltes():ParamsFilterModelDto
+    fun getParamsFiltres():ParamsFilterModelDto?
 }

--- a/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorage.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorage.kt
@@ -1,0 +1,8 @@
+package ru.practicum.android.diploma.sharedPref.impl
+
+interface FiltersStorage {
+
+    fun getStateSavedFilters():Boolean
+
+    fun getParamsFiltes():
+}

--- a/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorage.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorage.kt
@@ -1,8 +1,10 @@
 package ru.practicum.android.diploma.sharedPref.impl
 
+import ru.practicum.android.diploma.filter.data.impl.dto.ParamsFilterModelDto
+
 interface FiltersStorage {
 
     fun getStateSavedFilters():Boolean
 
-    fun getParamsFiltes():
+    fun getParamsFiltes():ParamsFilterModelDto
 }

--- a/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorageImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorageImpl.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import ru.practicum.android.diploma.filter.data.impl.dto.ParamsFilterModelDto
+import ru.practicum.android.diploma.sharedPref.FiltersStorage
 
 class FiltersStorageImpl(
     private val sharedPref: SharedPreferences,

--- a/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorageImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorageImpl.kt
@@ -2,17 +2,37 @@ package ru.practicum.android.diploma.sharedPref.impl
 
 import android.content.SharedPreferences
 import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import ru.practicum.android.diploma.filter.data.impl.dto.ParamsFilterModelDto
 
 class FiltersStorageImpl(
     private val sharedPref: SharedPreferences,
     private val gson: Gson): FiltersStorage {
 
-    override fun getParamsFiltes(): ParamsFilterModelDto {
-        TODO("Not yet implemented")
+    companion object {
+        const val KEY_SAVED_PARAMS_FILTER = "key_saved_params"
+
+        //Данный ключ для сохранения статуса, наличия, отсутствия параметров в хранилище
+        //В дальнейшем может быть использован в функции setStatusParamsFilter
+        const val KEY_STATUS_PARAMS_FILTER = "key_status_params"
     }
 
+    /**
+     * Simple function for get saved filters from storage.
+     * @return ParamsFilterModelDto
+     */
+    override fun getParamsFiltes(): ParamsFilterModelDto {
+        val jsonSavedParams = sharedPref.getString(KEY_SAVED_PARAMS_FILTER,null)
+        val itemType = object : TypeToken<ParamsFilterModelDto>(){}.type
+
+        return gson.fromJson(jsonSavedParams,itemType)
+    }
+
+    /**
+     * Simple function for get save status filters from storage.
+     * @return Boolean
+     */
     override fun getStateSavedFilters(): Boolean {
-        TODO("Not yet implemented")
+        return sharedPref.getBoolean(KEY_STATUS_PARAMS_FILTER,false)
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorageImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorageImpl.kt
@@ -12,17 +12,13 @@ class FiltersStorageImpl(
 
     companion object {
         const val KEY_SAVED_PARAMS_FILTER = "key_saved_params"
-
-        //Данный ключ для сохранения статуса, наличия, отсутствия параметров в хранилище
-        //В дальнейшем может быть использован в функции setStatusParamsFilter
-        const val KEY_STATUS_PARAMS_FILTER = "key_status_params"
     }
 
     /**
      * Simple function for get saved filters from storage.
      * @return ParamsFilterModelDto
      */
-    override fun getParamsFiltres(): ParamsFilterModelDto? {
+    override fun getParamsFilters(): ParamsFilterModelDto? {
         val jsonSavedParams = sharedPref.getString(KEY_SAVED_PARAMS_FILTER,null)
         val itemType = object : TypeToken<ParamsFilterModelDto>(){}.type
 
@@ -30,5 +26,14 @@ class FiltersStorageImpl(
             return null
         }
         return gson.fromJson(jsonSavedParams,itemType)
+    }
+
+    /**
+     * Simple function for add filters in storage.
+     */
+    override fun addParamsFilters(params:ParamsFilterModelDto) {
+         sharedPref.edit()
+             .putString(KEY_SAVED_PARAMS_FILTER,gson.toJson(params))
+             .apply()
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorageImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorageImpl.kt
@@ -1,0 +1,18 @@
+package ru.practicum.android.diploma.sharedPref.impl
+
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import ru.practicum.android.diploma.filter.data.impl.dto.ParamsFilterModelDto
+
+class FiltersStorageImpl(
+    private val sharedPref: SharedPreferences,
+    private val gson: Gson): FiltersStorage {
+
+    override fun getParamsFiltes(): ParamsFilterModelDto {
+        TODO("Not yet implemented")
+    }
+
+    override fun getStateSavedFilters(): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorageImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/sharedPref/impl/FiltersStorageImpl.kt
@@ -22,18 +22,13 @@ class FiltersStorageImpl(
      * Simple function for get saved filters from storage.
      * @return ParamsFilterModelDto
      */
-    override fun getParamsFiltes(): ParamsFilterModelDto {
+    override fun getParamsFiltres(): ParamsFilterModelDto? {
         val jsonSavedParams = sharedPref.getString(KEY_SAVED_PARAMS_FILTER,null)
         val itemType = object : TypeToken<ParamsFilterModelDto>(){}.type
 
+        if (jsonSavedParams == null || jsonSavedParams == "") {
+            return null
+        }
         return gson.fromJson(jsonSavedParams,itemType)
-    }
-
-    /**
-     * Simple function for get save status filters from storage.
-     * @return Boolean
-     */
-    override fun getStateSavedFilters(): Boolean {
-        return sharedPref.getBoolean(KEY_STATUS_PARAMS_FILTER,false)
     }
 }


### PR DESCRIPTION
- Добавлены модели domain и dto для сохранения фильтров. Прошу посмотреть насколько они корректные и полностью ли подходят по фитчу фильтров. Модель формировался на основе APIHh.  
- Добавлен маппер для моделей, через анонимный объект.
- Добавлена реализация sharePref, через модуль di
- Добавлен клиент sharedPref отдельным пакетов, который в дальнем необходимо передавать в репозиторий фитчей, в виде интерфейса FiltersStorage
- Реализованы функции получения сохраненных настроек фильтров, а так же статуса наличия фильтров в хранилище, через возвращение булево значения. Булево значение хранится с использованием отдельного ключа. 
------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Далее необходимо реализовать функции сохранения настроек, при реализации фитчи фильтры. Можно давить отдельной таской в эпики фильтры, либо тех.
