### PR TITLE
WorkPlace фрагмент переделан с использованием StateFlow ScreenWorkPla…

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/filter/data/repository/FiltersRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/data/repository/FiltersRepositoryImpl.kt
@@ -20,7 +20,7 @@ class FiltersRepositoryImpl(private val sharedPrefsClient: FiltersStorage) : Fil
         nameArea = null,
         nameIndustry = null,
         currency = null,
-        salary = 0,
+        salary = null,
         onlyWithSalary = false,
     )
 

--- a/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/Country.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/Country.kt
@@ -3,20 +3,32 @@ package ru.practicum.android.diploma.filter.presentation.fragment
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
-import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import ru.practicum.android.diploma.R
-import ru.practicum.android.diploma.filter.presentation.util.KEY_COUNTRY_RESULT
+import ru.practicum.android.diploma.filter.presentation.sharedviewmodel.FilterSharedVm
 import ru.practicum.android.diploma.filter.presentation.util.ParentDataFragment
 import ru.practicum.android.diploma.filter.presentation.view_model.CountryVm
 
 class Country : ParentDataFragment() {
     override val vm: CountryVm by viewModel()
+    private val sharedFiltersVm: FilterSharedVm by activityViewModels()
 
     override fun exitExtraWhenSystemBackPushed() {
-        // Для поиска вакансии по региону необходимо передать в поисковый запрос id региона
-        setFragmentResult(KEY_COUNTRY_RESULT, getBackSendData())
+        val filterSet = sharedFiltersVm.getFilters()
+        val newCountry = vm.dataToSendBack
+
+        filterSet?.let {
+            val filter = when (newCountry) {
+                null -> it.copy(idCountry = null, nameCountry = null)
+                else -> it.copy(idCountry = newCountry.id.toString(), nameCountry = newCountry.name)
+            }
+
+            // Передаем изменения в sharedFiltersVm
+            sharedFiltersVm.setFilter(remoteFilter = filter)
+        }
+
         findNavController().popBackStack()
     }
 

--- a/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/District.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/District.kt
@@ -2,26 +2,39 @@ package ru.practicum.android.diploma.filter.presentation.fragment
 
 import android.os.Bundle
 import android.view.View
-import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import ru.practicum.android.diploma.filter.presentation.sharedviewmodel.FilterSharedVm
 import ru.practicum.android.diploma.filter.presentation.util.ARG_COUNTRY_ID
-import ru.practicum.android.diploma.filter.presentation.util.KEY_DISTRICT_RESULT
 import ru.practicum.android.diploma.filter.presentation.util.ParentDataFragment
 import ru.practicum.android.diploma.filter.presentation.view_model.DistrictVm
-import ru.practicum.android.diploma.filter.recycler.AreaAdapter
 
 open class District : ParentDataFragment() {
     override val vm: DistrictVm by viewModel()
+    private val sharedFiltersVm: FilterSharedVm by activityViewModels()
 
     override fun exitExtraWhenSystemBackPushed() {
-        // Для поиска вакансии по региону необходимо передать в поисковый запрос id региона
-        setFragmentResult(KEY_DISTRICT_RESULT, getBackSendData())
+        val filterSet = sharedFiltersVm.getFilters()
+        val newArea = vm.dataToSendBack
+
+        filterSet?.let {
+            val filter = when (newArea) {
+                null -> it.copy(idArea = null, nameArea = null)
+                else -> it.copy(idArea = newArea.id.toString(), nameArea = newArea.name)
+            }
+
+            // Передаем изменения в sharedFiltersVm
+            sharedFiltersVm.setFilter(remoteFilter = filter)
+        }
         findNavController().popBackStack()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Распаковка переданного аргумента
+        // В аргументе хранится id региона по которому, будет вестись поиск внутренних регионов
+
         arguments?.let {
             paramCountryId = it.getInt(ARG_COUNTRY_ID)
         }

--- a/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/Filters.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/Filters.kt
@@ -96,7 +96,12 @@ class Filters : DefaultFragment<FragmentFiltersBinding>() {
                 exitExtraWhenSystemBackPushed()
             }
 
-            btnDeclineFilterSet.setOnClickListener { vm.abortFilters() }
+            btnDeclineFilterSet.setOnClickListener {
+                vm.abortFilters()
+
+                // Загружаем прежние данные в sharedViewModel
+                sharedViewModel.setFilter(vm.getFilters())
+            }
 
             btnClrWorkPlace.setOnClickListener {
                 vm.clearWorkPlace()

--- a/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/Filters.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/Filters.kt
@@ -22,7 +22,6 @@ import ru.practicum.android.diploma.databinding.FragmentFiltersBinding
 import ru.practicum.android.diploma.filter.domain.models.FilterData
 import ru.practicum.android.diploma.filter.presentation.sharedviewmodel.FilterSharedVm
 import ru.practicum.android.diploma.filter.presentation.util.KEY_FILTERS_RESULT
-import ru.practicum.android.diploma.filter.presentation.util.ScreenState
 import ru.practicum.android.diploma.filter.presentation.view_model.FiltersVm
 import ru.practicum.android.diploma.util.DefaultFragment
 
@@ -131,9 +130,10 @@ class Filters : DefaultFragment<FragmentFiltersBinding>() {
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 vm.screenState.collect {
-                    if (it is ScreenState.FilterSettings) {
-                        renderFilterSettings(it.filters)
+                    if (it is ScreenFiltersState.Content) {
+                        renderFilterSettings(it.filterSet)
                         renderAcceptChangeBtn(it.btnAcceptVisibility)
+                        renderDeclineChangeBtn(it.btnDeclineVisibility)
                     }
                 }
             }
@@ -142,13 +142,12 @@ class Filters : DefaultFragment<FragmentFiltersBinding>() {
 
     override fun onResume() {
         super.onResume()
-        Log.e("LOG", "OnResume")
-
 
         // При возвращении на фрагмент собираем потенциально полученную информацию
         // от фрагментов выбора страны, региона, профессии
         sharedViewModel.getFilters()?.let {
             vm.updateFiltersWithRemote(it)
+            Log.e("LOG", "OnResume $it")
         }
     }
 
@@ -208,6 +207,9 @@ class Filters : DefaultFragment<FragmentFiltersBinding>() {
 
     private fun renderAcceptChangeBtn(visibility: Boolean) {
         binding.btnAcceptFilterSet.isVisible = visibility
+    }
+
+    private fun renderDeclineChangeBtn(visibility: Boolean) {
         binding.btnDeclineFilterSet.isVisible = visibility
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/Filters.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/Filters.kt
@@ -75,7 +75,7 @@ class Filters : DefaultFragment<FragmentFiltersBinding>() {
                         val pStr = vm.setNewSalaryToFilter(s)
 
                         // Ноль отображаем как пустое поле для ввода зп
-                        if (pStr == "0") binding.txtSalaryInput.setText("")
+                        if (pStr == null) binding.txtSalaryInput.setText("")
                         else {
                             binding.txtSalaryInput.setText(pStr)
                             binding.txtSalaryInput.setSelection(pStr.length)

--- a/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/ScreenFiltersState.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/ScreenFiltersState.kt
@@ -1,0 +1,13 @@
+package ru.practicum.android.diploma.filter.presentation.fragment
+
+import ru.practicum.android.diploma.filter.domain.models.FilterData
+
+sealed class ScreenFiltersState {
+    data class Content(
+        val filterSet: FilterData,
+        val btnAcceptVisibility: Boolean,
+        val btnDeclineVisibility:Boolean
+    ) : ScreenFiltersState()
+
+    data class Loading(val code: Any?) : ScreenFiltersState()
+}

--- a/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/ScreenWorkPlaceState.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/presentation/fragment/ScreenWorkPlaceState.kt
@@ -1,0 +1,12 @@
+package ru.practicum.android.diploma.filter.presentation.fragment
+
+import ru.practicum.android.diploma.filter.domain.models.FilterData
+
+sealed class ScreenWorkPlaceState {
+    data class Content(
+        val filterSet: FilterData,
+        val btnAcceptVisibility: Boolean
+    ) : ScreenWorkPlaceState()
+
+    data class Loading(val code: Any?) : ScreenWorkPlaceState()
+}

--- a/app/src/main/java/ru/practicum/android/diploma/filter/presentation/sharedviewmodel/FilterSharedVm.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/presentation/sharedviewmodel/FilterSharedVm.kt
@@ -1,6 +1,5 @@
 package ru.practicum.android.diploma.filter.presentation.sharedviewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import ru.practicum.android.diploma.filter.domain.models.AbstractData
 import ru.practicum.android.diploma.filter.domain.models.FilterData
@@ -9,26 +8,11 @@ class FilterSharedVm : ViewModel() {
     private var filters: FilterData? = null
 
     fun setFilter(remoteFilter: FilterData) {
-        if(filters==null) filters = remoteFilter
-        Log.e("LOG", "Shared $filters")
-
+        filters = remoteFilter
     }
 
-    fun deleteFilters(){
+    fun deleteFilters() {
         filters = null
-    }
-
-    fun setCountry(country: AbstractData) {
-        filters?.let {
-            filters = it.copy(idCountry = country.id.toString(), nameCountry = country.name)
-        }
-
-    }
-
-    fun setDistrict(district: AbstractData) {
-        filters?.let {
-            filters = it.copy(idArea = district.id.toString(), nameArea = district.name)
-        }
     }
 
     fun setIndustry(industry: AbstractData) {

--- a/app/src/main/java/ru/practicum/android/diploma/filter/presentation/util/ParentDataFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/presentation/util/ParentDataFragment.kt
@@ -17,16 +17,7 @@ import ru.practicum.android.diploma.filter.recycler.AreaAdapter
 import ru.practicum.android.diploma.util.DefaultFragment
 
 const val ARG_COUNTRY_ID = "country_id_pram"
-
-const val KEY_DISTRICT_RESULT = "district_result"
-const val KEY_COUNTRY_RESULT = "area_result"
-const val KEY_INDUSTRY_RESULT = "industry_result"
-const val KEY_FILTERS_RESULT ="filters_result"
-
-const val AREA_ID = "area_id_param"
-const val AREA_NAME = "area_name_param"
-const val INDUSTRY_ID = "industry_id_param"
-const val INDUSTRY_NAME = "industry_name_param"
+const val KEY_FILTERS_RESULT = "filters_result"
 
 open class ParentDataFragment : DefaultFragment<FragmentDistrictBinding>() {
     protected var paramCountryId: Int? = null // Считывается из аргументов в onCreate
@@ -93,15 +84,6 @@ open class ParentDataFragment : DefaultFragment<FragmentDistrictBinding>() {
         binding.areaRecycler.layoutManager = LinearLayoutManager(requireContext())
     }
 
-    open fun getBackSendData(): Bundle {
-        return Bundle().apply {
-            vm?.dataToSendBack?.let { data ->
-                putInt(AREA_ID, data.id)
-                putString(AREA_NAME, data.name)
-            }
-        }
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setUpAdapter()
@@ -137,6 +119,4 @@ open class ParentDataFragment : DefaultFragment<FragmentDistrictBinding>() {
             else -> {}
         }
     }
-
-
 }

--- a/app/src/main/java/ru/practicum/android/diploma/filter/presentation/view_model/CountryVm.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/presentation/view_model/CountryVm.kt
@@ -13,10 +13,8 @@ class CountryVm(private val areaController: AreaController) : DefaultViewModel()
         loadCountryList()
     }
 
-    fun loadCountryList() {
+    private fun loadCountryList() {
         viewModelScope.launch {
-            //Данные названия не менял на getAreas и getDistricts соответственно. Можно поменять.
-
             areaController.loadCountries().collect {
                 when (it) {
                     is DataStatus.Loading -> _screenState.value = ScreenState.Loading(null)

--- a/app/src/main/java/ru/practicum/android/diploma/filter/presentation/view_model/FiltersVm.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/presentation/view_model/FiltersVm.kt
@@ -1,11 +1,13 @@
 package ru.practicum.android.diploma.filter.presentation.view_model
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import ru.practicum.android.diploma.filter.domain.interfaces.FiltersController
 import ru.practicum.android.diploma.filter.domain.models.FilterData
 import ru.practicum.android.diploma.filter.presentation.fragment.ScreenFiltersState
+import kotlin.math.log
 
 class FiltersVm(private val filtersController: FiltersController) : ViewModel() {
 
@@ -36,19 +38,16 @@ class FiltersVm(private val filtersController: FiltersController) : ViewModel() 
 
     fun getFilters() = newFilterSet
 
-    fun setNewSalaryToFilter(incomeStr: CharSequence?): String {
-        if (incomeStr.isNullOrEmpty()) {
-            // If text from salaryInput has been cleared via delete button
-            // Set salary to zero
-            newFilterSet = newFilterSet.copy(salary = 0)
-
+    fun setNewSalaryToFilter(incomeStr: CharSequence?): String? {
+        if(incomeStr.isNullOrEmpty()) {
+            newFilterSet = newFilterSet.copy(salary = null)
             // Invalidate screen (to update accept_button visibility
             _screenState.value = ScreenFiltersState.Content(
                 newFilterSet,
                 compareFilters(),
                 compareFiltersWithDefault()
             )
-            return "0"
+            return ""
         }
 
         val newSalary = incomeStr.toString().toIntOrNull()
@@ -66,7 +65,9 @@ class FiltersVm(private val filtersController: FiltersController) : ViewModel() 
 
             newFilterSet.salary.toString()
         } else {
-            newFilterSet.salary.toString()
+            Log.e("Log","return ${newFilterSet.salary.toString()}")
+            if (newFilterSet.salary!=null) return newFilterSet.salary.toString()
+            else return ""
         }
     }
 

--- a/app/src/main/java/ru/practicum/android/diploma/filter/presentation/view_model/FiltersVm.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filter/presentation/view_model/FiltersVm.kt
@@ -1,6 +1,5 @@
 package ru.practicum.android.diploma.filter.presentation.view_model
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,10 +19,6 @@ class FiltersVm(private val filtersController: FiltersController) : ViewModel() 
 
 
     init {
-        Log.e("LOG","Init")
-        val num = "-45".toIntOrNull()
-        Log.e("LOG","num = $num")
-
         loadFilterSet()
     }
 
@@ -38,8 +33,8 @@ class FiltersVm(private val filtersController: FiltersController) : ViewModel() 
 
     fun getFilters() = newFilterSet
 
-    fun setNewSalaryToFilter(incomeStr: CharSequence?):String {
-        if(incomeStr.isNullOrEmpty()){
+    fun setNewSalaryToFilter(incomeStr: CharSequence?): String {
+        if (incomeStr.isNullOrEmpty()) {
             // If text from salaryInput has been cleared via delete button
             // Set salary to zero
             newFilterSet = newFilterSet.copy(salary = 0)
@@ -51,7 +46,7 @@ class FiltersVm(private val filtersController: FiltersController) : ViewModel() 
 
         val newSalary = incomeStr.toString().toIntOrNull()
 
-        return if(newSalary!==null && newSalary>=0){
+        return if (newSalary !== null && newSalary >= 0) {
             // if inputSalary is correct, save salary in new filter set
             newFilterSet = newFilterSet.copy(salary = newSalary)
 
@@ -59,7 +54,7 @@ class FiltersVm(private val filtersController: FiltersController) : ViewModel() 
             _screenState.value = ScreenState.FilterSettings(newFilterSet, compareFilters())
 
             newFilterSet.salary.toString()
-        } else{
+        } else {
             newFilterSet.salary.toString()
         }
     }
@@ -91,14 +86,15 @@ class FiltersVm(private val filtersController: FiltersController) : ViewModel() 
         _screenState.value = ScreenState.FilterSettings(newFilterSet, compareFilters())
     }
 
-    fun clearWorkPlace(){
-        newFilterSet = newFilterSet.copy(idCountry = null,idArea = null, nameCountry = null, nameArea = null)
+    fun clearWorkPlace() {
+        newFilterSet =
+            newFilterSet.copy(idCountry = null, idArea = null, nameCountry = null, nameArea = null)
 
         // Invalidate screen
         _screenState.value = ScreenState.FilterSettings(newFilterSet, compareFilters())
     }
 
-    fun clearIndustry(){
+    fun clearIndustry() {
         newFilterSet = newFilterSet.copy(idIndustry = null, nameIndustry = null)
 
         // Invalidate screen


### PR DESCRIPTION
### DONE

- [x] Фрагмент WorkPlace переделан (вместо нескольких liveData используется sateFlow
- [x] Возврат значений из фрагментов выбора Страны и Региона реализован через sharedViewModel

Доделал следующие пункты ТЗ

- [x] Если в настройках фильтрации уже есть выбранные значения для места работы, то на экране выбора места работы отображаются соответствующая страна и регион. В противном случае область для отображения страны и региона должна быть пустой.